### PR TITLE
refactor: set mimeType to null on StorageReferenceFetcher

### DIFF
--- a/firecoil/src/main/java/io/github/rosariopfernandes/firecoil/StorageReferenceFetcher.kt
+++ b/firecoil/src/main/java/io/github/rosariopfernandes/firecoil/StorageReferenceFetcher.kt
@@ -7,7 +7,6 @@ import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.fetch.SourceResult
 import coil.size.Size
-import com.google.firebase.storage.StorageException
 import com.google.firebase.storage.StorageReference
 import kotlinx.coroutines.tasks.await
 import okio.buffer
@@ -21,28 +20,16 @@ class StorageReferenceFetcher : Fetcher<StorageReference> {
         size: Size,
         options: Options
     ): FetchResult {
-        val source = data.stream.await()
-
-        var mimeType: String?
-
-        try {
-            val metadata = data.metadata.await()
-            mimeType = metadata.contentType
-        } catch (e: StorageException) {
-            mimeType = null
-        }
+        val taskSnapshot = data.stream.await()
 
         return SourceResult(
             dataSource = DataSource.NETWORK,
-            source = source.stream.source().buffer(),
-            mimeType = mimeType
+            source = taskSnapshot.stream.source().buffer(),
+            mimeType = null
         )
     }
 
     override fun key(data: StorageReference) = data.path
 
-    override fun handles(data: StorageReference): Boolean {
-        // TODO: Return true if the StorageReference points to a file
-        return true
-    }
+    override fun handles(data: StorageReference) = true
 }


### PR DESCRIPTION
Fetching the metadata only to get the mimeType can have a small
 impact on performance, since we're making a second network call
 in order to retrieve it. I suggest we keep the mimeType null,
 and if the user needs to get it, they should call "getMetadata()"
 on the StorageReference instead.